### PR TITLE
Invalidate async operations with invalidatingOperationsDescriptorIds

### DIFF
--- a/src/__tests__/__snapshots__/asyncOperationManagerUtils_test.js.snap
+++ b/src/__tests__/__snapshots__/asyncOperationManagerUtils_test.js.snap
@@ -5,6 +5,7 @@ Object {
   "alwaysImmutable": false,
   "debug": false,
   "descriptorId": "FETCH_PERSON_DATA_BY_ID",
+  "invalidatingOperationsDescriptorIds": null,
   "maxCacheTime": 60000,
   "minCacheTime": 5000,
   "operationType": "READ",

--- a/src/__tests__/__snapshots__/asyncOperationStateUtils_test.js.snap
+++ b/src/__tests__/__snapshots__/asyncOperationStateUtils_test.js.snap
@@ -23,6 +23,19 @@ Object {
 }
 `;
 
+exports[`asyncOperationStateUtils getAsyncOperation should invalidate async operation if an invalidatingAsyncOperation has a resolve timestamp after async operation: well formed successful asyncOperation with parentAsyncOperation metaData two levels deep 1`] = `
+Object {
+  "appointmentId": 111,
+  "dataStatus": "ABSENT",
+  "descriptorId": "FETCH_APPOINTMENT_DATA",
+  "fetchStatus": "NULL",
+  "lastDataStatusTime": 0,
+  "lastFetchFailed": false,
+  "lastFetchStatusTime": 0,
+  "message": null,
+}
+`;
+
 exports[`asyncOperationStateUtils getAsyncOperation should return a pending asyncOperation: well formed pending asyncOperation 1`] = `
 Object {
   "dataStatus": "ABSENT",
@@ -55,6 +68,7 @@ Object {
   "descriptorId": "FETCH_PERSON_DATA",
   "fetchStatus": "SUCCESSFUL",
   "lastDataStatusTime": "2018-10-01T19:13:56.189Z",
+  "lastFetchFailed": false,
   "lastFetchStatusTime": "2018-10-01T19:13:52.189Z",
   "message": null,
   "personId": 111,
@@ -115,6 +129,7 @@ Object {
     "alwaysImmutable": false,
     "debug": false,
     "descriptorId": "UPDATE_PERSON_DATA",
+    "invalidatingOperationsDescriptorIds": null,
     "maxCacheTime": 60000,
     "minCacheTime": 5000,
     "operationType": "WRITE",

--- a/src/__tests__/__snapshots__/asyncOperationStateUtils_test.js.snap
+++ b/src/__tests__/__snapshots__/asyncOperationStateUtils_test.js.snap
@@ -23,6 +23,19 @@ Object {
 }
 `;
 
+exports[`asyncOperationStateUtils getAsyncOperation should invalidate async operation if an invalidatingAsyncOperation has a resolve timestamp after async operation and is two levels deep: well formed successful asyncOperation with parentAsyncOperation metaData two levels deep 1`] = `
+Object {
+  "appointmentId": 111,
+  "dataStatus": "ABSENT",
+  "descriptorId": "FETCH_APPOINTMENT_DATA",
+  "fetchStatus": "NULL",
+  "lastDataStatusTime": 0,
+  "lastFetchFailed": false,
+  "lastFetchStatusTime": 0,
+  "message": null,
+}
+`;
+
 exports[`asyncOperationStateUtils getAsyncOperation should invalidate async operation if an invalidatingAsyncOperation has a resolve timestamp after async operation: well formed successful asyncOperation with parentAsyncOperation metaData two levels deep 1`] = `
 Object {
   "appointmentId": 111,

--- a/src/__tests__/asyncOperationManagerUtils_test.js
+++ b/src/__tests__/asyncOperationManagerUtils_test.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import {
   getAsyncOperationsManagerState,
   registerAsyncOperationDescriptors,
-  getAsyncOperationDescriptor,
   getStateForOperationAfterStep,
 } from '../asyncOperationManagerUtils';
 
@@ -14,7 +13,7 @@ import {
 
 const initialState = {
   operations: {},
-}
+};
 
 describe('asyncOperationManagerUtils', () => {
   let state;
@@ -70,7 +69,9 @@ describe('asyncOperationManagerUtils', () => {
         minCacheTime: 5000,
         maxCacheTime: 60000,
       });
-      const asyncOperationDescriptor = getAsyncOperationDescriptor('FETCH_PERSON_DATA_BY_ID');
+
+      const { descriptors: registeredAsyncDescriptors } = getAsyncOperationsManagerState(state);
+      const asyncOperationDescriptor = registeredAsyncDescriptors.FETCH_PERSON_DATA_BY_ID;
       expect(asyncOperationDescriptor).to.be.an('object');
       expect(asyncOperationDescriptor).to.matchSnapshot('well formed async operation descriptor');
     });

--- a/src/__tests__/asyncOperationStateUtils_test.js
+++ b/src/__tests__/asyncOperationStateUtils_test.js
@@ -394,5 +394,45 @@ describe('asyncOperationStateUtils', () => {
       });
       expect(asyncOperation).to.matchSnapshot('well formed successful asyncOperation with parentAsyncOperation metaData two levels deep');
     });
+
+    it('should invalidate async operation if an invalidatingAsyncOperation has a resolve timestamp after async operation and is two levels deep', () => {
+      state = {
+        operations: {
+          FETCH_APPOINTMENT_DATA_111: {
+            descriptorId: 'FETCH_APPOINTMENT_DATA',
+            fetchStatus: 'SUCCESSFUL',
+            dataStatus: 'PRESENT',
+            message: null,
+            lastFetchStatusTime: '2018-09-01T19:12:46.189Z',
+            lastDataStatusTime: '2018-09-01T19:12:53.189Z',
+            appointmentId: 111,
+          },
+          FETCH_APPOINTMENT_DATA_222: {
+            descriptorId: 'FETCH_APPOINTMENT_DATA',
+            fetchStatus: 'SUCCESSFUL',
+            dataStatus: 'PRESENT',
+            message: null,
+            lastFetchStatusTime: '2018-09-21T19:13:52.189Z',
+            lastDataStatusTime: '2018-09-21T19:13:56.189Z',
+            appointmentId: 222,
+          },
+        },
+      };
+
+      const fetchAppointmentDataAsyncOperationDescriptor = {
+        descriptorId: 'FETCH_APPOINTMENT_DATA',
+        requiredParams: ['appointmentId'],
+        operationType: 'READ',
+        invalidatingOperationsDescriptorIds: ['FETCH_PERSON_DATA'],
+      };
+
+      const asyncOperation = asyncOperationStateUtils.getAsyncOperation(state, 'fetchAppointmentData_111', fetchAppointmentDataAsyncOperationDescriptor, { appointmentId: 111 });
+      expect(asyncOperation).to.be.an('object');
+      expect(asyncOperation).to.deep.include({
+        lastFetchStatusTime: 0,
+        lastDataStatusTime: 0,
+      });
+      expect(asyncOperation).to.matchSnapshot('well formed successful asyncOperation with parentAsyncOperation metaData two levels deep');
+    });
   });
 });

--- a/src/__tests__/asyncOperationStateUtils_test.js
+++ b/src/__tests__/asyncOperationStateUtils_test.js
@@ -283,7 +283,7 @@ describe('asyncOperationStateUtils', () => {
         parentOperationDescriptorId: 'FETCH_ALL_PERSON_DATA',
       };
 
-      const asyncOperation = asyncOperationStateUtils.getAsyncOperation(state, 'FETCH_PERSON_DATA_111', fetchPersonDataAsyncOperationDescriptor, { personId: 111 });
+      const asyncOperation = asyncOperationStateUtils.getAsyncOperation(state, 'fetchPersonData_111', fetchPersonDataAsyncOperationDescriptor, { personId: 111 });
       expect(asyncOperation).to.be.an('object');
       expect(asyncOperation).to.deep.include({
         lastFetchStatusTime: '2018-10-01T19:13:52.189Z',
@@ -291,6 +291,7 @@ describe('asyncOperationStateUtils', () => {
       });
       expect(asyncOperation).to.matchSnapshot('well formed successful asyncOperation with parentAsyncOperation metaData');
     });
+
     it('should return a successful asyncOperation with parentAsyncOperation metaData two levels deep', () => {
       state = {
         operations: {
@@ -350,6 +351,46 @@ describe('asyncOperationStateUtils', () => {
       expect(asyncOperation).to.deep.include({
         lastFetchStatusTime: '2018-10-01T19:16:52.189Z',
         lastDataStatusTime: '2018-10-01T19:23:56.189Z',
+      });
+      expect(asyncOperation).to.matchSnapshot('well formed successful asyncOperation with parentAsyncOperation metaData two levels deep');
+    });
+
+    it('should invalidate async operation if an invalidatingAsyncOperation has a resolve timestamp after async operation', () => {
+      state = {
+        operations: {
+          FETCH_APPOINTMENT_DATA_111: {
+            descriptorId: 'FETCH_APPOINTMENT_DATA',
+            fetchStatus: 'SUCCESSFUL',
+            dataStatus: 'PRESENT',
+            message: null,
+            lastFetchStatusTime: '2018-09-01T19:12:46.189Z',
+            lastDataStatusTime: '2018-09-01T19:12:53.189Z',
+            appointmentId: 111,
+          },
+          FETCH_APPOINTMENT_DATA_222: {
+            descriptorId: 'FETCH_APPOINTMENT_DATA',
+            fetchStatus: 'SUCCESSFUL',
+            dataStatus: 'PRESENT',
+            message: null,
+            lastFetchStatusTime: '2018-09-21T19:13:52.189Z',
+            lastDataStatusTime: '2018-09-21T19:13:56.189Z',
+            appointmentId: 222,
+          },
+        },
+      };
+
+      const fetchAppointmentDataAsyncOperationDescriptor = {
+        descriptorId: 'FETCH_APPOINTMENT_DATA',
+        requiredParams: ['appointmentId'],
+        operationType: 'READ',
+        invalidatingOperationsDescriptorIds: ['FETCH_PERSON_DATA'],
+      };
+
+      const asyncOperation = asyncOperationStateUtils.getAsyncOperation(state, 'fetchAppointmentData_111', fetchAppointmentDataAsyncOperationDescriptor, { appointmentId: 111 });
+      expect(asyncOperation).to.be.an('object');
+      expect(asyncOperation).to.deep.include({
+        lastFetchStatusTime: 0,
+        lastDataStatusTime: 0,
       });
       expect(asyncOperation).to.matchSnapshot('well formed successful asyncOperation with parentAsyncOperation metaData two levels deep');
     });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,33 +1,45 @@
 // TODO: JSDocify every function
 
-import _ from 'lodash';
-import asyncOperationMangerConfig from './config';
+import {
+  assign,
+  every,
+  keyBy,
+  has,
+  isString,
+  partial,
+  pick,
+  omit,
+  some,
+  values,
+} from 'lodash';
+
+import asyncOperationManagerConfig from './config';
 
 const makeConstantsObject = (sourceValues = [], extraOverrides = {}) =>
   Object.freeze(
     // The keyBy create our keys-and-values object, then we manipulate it and freeze it.s
-    _.assign(_.keyBy(sourceValues), extraOverrides)
+    assign(keyBy(sourceValues), extraOverrides)
   );
 
 
 const generateAsyncOperationKey = (descriptorId, requiredParams) => {
-  const config = asyncOperationMangerConfig.getConfig();
+  const config = asyncOperationManagerConfig.getConfig();
   
-  if (!descriptorId || !_.isString(descriptorId)) {
+  if (!descriptorId || !isString(descriptorId)) {
     config.logger.exceptionsCallback('A descriptorId string to create the async operation key was not provided');
   }
   if (requiredParams) {
-    return `${descriptorId}_${_.values(requiredParams).join('_')}`;
+    return `${descriptorId}_${values(requiredParams).join('_')}`;
   }
   return descriptorId;
 };
 
 const getAndValidateParams = (paramsToCheck, asyncOperationDescriptor) => {
   let asyncOperationParams = null;
-  const { logger } = asyncOperationMangerConfig.getConfig();
+  const { logger } = asyncOperationManagerConfig.getConfig();
   if (asyncOperationDescriptor.requiredParams) {
-    asyncOperationParams = asyncOperationDescriptor.requiredParams ? _.pick(paramsToCheck, asyncOperationDescriptor.requiredParams) : null;
-    if (!_.every(asyncOperationDescriptor.requiredParams, _.partial(_.has, asyncOperationParams)) || (asyncOperationParams && _.some(asyncOperationParams, paramValue => !paramValue))) {
+    asyncOperationParams = asyncOperationDescriptor.requiredParams ? pick(paramsToCheck, asyncOperationDescriptor.requiredParams) : null;
+    if (!every(asyncOperationDescriptor.requiredParams, partial(has, asyncOperationParams)) || (asyncOperationParams && some(asyncOperationParams, paramValue => !paramValue))) {
       // This warning is here just to catch typos
       logger.exceptionsCallback(`
         It looks like ${asyncOperationDescriptor.descriptorId} is missing a param/requiredParams.
@@ -40,8 +52,43 @@ const getAndValidateParams = (paramsToCheck, asyncOperationDescriptor) => {
   return asyncOperationParams;
 };
 
+const getAsyncOperationDescriptor = (asyncOperationDescriptors, descriptorId) => {
+  const config = asyncOperationManagerConfig.getConfig();
+  const asyncOperationDescriptor = asyncOperationDescriptors[descriptorId];
+
+  if (!asyncOperationDescriptor) {
+    config.logger.warningsCallback(`descriptorId "${descriptorId}" does not match with any registered async operation descriptor`);
+    return null;
+  }
+
+  if (asyncOperationDescriptor.debug) {
+    config.logger.verboseLoggingCallback(`Inside getAsyncOperationDescriptor for ${descriptorId}`);
+    config.logger.infoLoggingCallback('getAsyncOperationDescriptor [Data Snapshot]:', {
+      asyncOperationDescriptors,
+      asyncOperationDescriptor,
+    });
+  }
+
+  return asyncOperationDescriptor;
+};
+
+const getAsyncOperationInfo = (descriptors, descriptorId, params) => {
+  const asyncOperationDescriptor = getAsyncOperationDescriptor(descriptors, descriptorId);
+  const asyncOperationParams = getAndValidateParams(params, asyncOperationDescriptor);
+  const asyncOperationKey = generateAsyncOperationKey(descriptorId, asyncOperationParams);
+  const otherFields = omit(params, asyncOperationDescriptor.requiredParams);
+
+  return {
+    asyncOperationDescriptor,
+    asyncOperationParams,
+    asyncOperationKey,
+    otherFields,
+  };
+};
+
 export {
   makeConstantsObject,
   generateAsyncOperationKey,
   getAndValidateParams,
+  getAsyncOperationInfo,
 };

--- a/src/types/asyncOperationUtils.types.js
+++ b/src/types/asyncOperationUtils.types.js
@@ -20,5 +20,6 @@ export const asyncOperationDescriptorPropType = {
   descriptorId: PropTypes.string.isRequired,
   requiredParams: PropTypes.arrayOf(PropTypes.string),
   parentOperationDescriptorId: PropTypes.string,
+  invalidatingOperationsDescriptorIds: PropTypes.arrayOf(PropTypes.string),
   operationType: PropTypes.oneOf(_.values(ASYNC_OPERATION_TYPES)).isRequired,
 };


### PR DESCRIPTION
Add invalidatingOperationsDescriptorIds property to AOM descriptors.

Allows an operation to return to an initial read/write state based on another operation's dataStatus.
